### PR TITLE
fixed an error in check_word

### DIFF
--- a/test_words.py
+++ b/test_words.py
@@ -22,6 +22,8 @@ def test_compare():
 	assert(words.compare('table','tower') == ['G', 'B', 'B', 'B', 'Y' ])
 	assert(words.compare('books','sport') == ['B', 'B', 'G', 'B', 'Y' ])
 	assert(words.compare('sport','books') == ['Y', 'B', 'G', 'B', 'B' ])
+	assert(words.compare('spook', 'troon') == ['B', 'B', 'G', 'G', 'B' ])
+	assert(words.compare('sopok', 'troon') == ['B', 'Y', 'B', 'G', 'B' ])
 
 def test_sort():
 	"""
@@ -37,3 +39,9 @@ def test_sort():
 	assert(np.all((words.sort(['above','wasps','zebra', 'wagon'], [1,2,3,4], 'wagor', ['G','G','G','G','B']))[1] == [4]))
 	assert(np.all((words.sort(['above','wasps','zebra', 'wagon'], [1,2,3,4], 'noawg', ['Y','Y','Y','Y','Y']))[0] == ['wagon']))
 	assert(np.all((words.sort(['above','wasps','zebra', 'wagon'], [1,2,3,4], 'noawg', ['Y','Y','Y','Y','Y']))[1] == [4]))
+
+def test_check_word():
+	"""
+	Test for the check_word function
+	"""
+	assert(words.check_word('aliuf',['a'],[0], ['i'] , [3] , ['g','a','n'] ) == True)

--- a/words.py
+++ b/words.py
@@ -139,21 +139,29 @@ def check_word(word,green_letters,green_indices, yellow_letters, yellow_indices,
 
 	if len(green_letters)!= 0:
 		for i in range(len(green_letters)):
+			print(word[green_indices[i]])
+			print(green_letters[i])
 			if word[green_indices[i]] != green_letters[i]:
+				print('green')
 				return False
 
 	if len(yellow_letters)!= 0:
 		for i in range(len(yellow_letters)):
 			if word[yellow_indices[i]] == yellow_letters[i] or (yellow_letters[i] not in word):
+				print('yellow')
 				return False			
 
 	if len(black_letters)!= 0:
 		for i in range(len(black_letters)):
-			if black_letters[i] in word:
+			#account for double letters in the guess but only one is in the answer (meaning all words with two occurences of that letter must be eliminated)
+			if ( (black_letters[i] in green_letters) or (black_letters[i] in yellow_letters) ):
+				if word.count(black_letters[i])>1: 
+					return False
+				else:
+					return True
+
+			elif black_letters[i] in word :
 				return False
 	#if all checks have passed then return True 
 	return True	
 
-	
-
-	


### PR DESCRIPTION
Fixed the check_word function to account for the following specific case: If a guess has twice the same letter, such as 'again', and one of the two 'a's is in the solution, such as 'axiom', then the previous version of check_word would delete the option 'axiom' because it has an 'a' and 'a' is both in the green_letters and in the black_letters. Now the function is coded in a way to make sure that this doesn't happen. A test has also been added to check this.